### PR TITLE
fix: confirm that keyword is v on converting obj to pcd

### DIFF
--- a/converter.cpp
+++ b/converter.cpp
@@ -45,6 +45,7 @@ void Converter::obj2pcd(const std::string& inputFilename, const std::string& out
 
         std::string v;
         in >> v;
+        if (v != "v") continue;
 
         // Read x y z
         float x, y, z;


### PR DESCRIPTION
- add check if keyword is "v".
- `.obj` file has other keywords in addition to `v`: `#`, `g`, `vt`, `vn`, `f`, and so on, and we should not count these keyword.
